### PR TITLE
Image pull secrets should be defined as kubernetes manifests.

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -2,19 +2,9 @@
 
 set -euo pipefail
 
-kubectl delete secret image-pull-secret 2>/dev/null || true
-
-if [ -n "${DOCKER_USERNAME:-}" ] && [ -n "${DOCKER_PASSWORD:-}" ]; then
-	echo "Creating DockerHub image-pull-secret from environment variables"
-	kubectl create secret docker-registry image-pull-secret \
-		--docker-server='https://index.docker.io/v1/' \
-		--docker-username="${DOCKER_USERNAME}" \
-		--docker-password="${DOCKER_PASSWORD}"
-fi
-
 while true; do
-	# recursively run envsubst on all files in /kubernetes
-	find /kubernetes -type f -name "*.yml" -exec sh -c 'envsubst < "$1" > "$1.tmp" && mv "$1.tmp" "$1"' _ {} \;
-	kubectl apply -k /kubernetes
-	sleep ${UPDATE_INTERVAL:-600}
+  # recursively run envsubst on all files in /kubernetes
+  find /kubernetes -type f -name "*.yml" -exec sh -c 'envsubst < "$1" > "$1.tmp" && mv "$1.tmp" "$1"' _ {} \;
+  kubectl apply -k /kubernetes
+  sleep ${UPDATE_INTERVAL:-600}
 done

--- a/kubernetes/image-pull-secret.yml
+++ b/kubernetes/image-pull-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: ${IMAGE_PULL_SECRET}
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: image-pull-secret
+type: kubernetes.io/dockerconfigjson
+

--- a/kubernetes/kustomization.yml
+++ b/kubernetes/kustomization.yml
@@ -5,6 +5,7 @@ resources:
   - ca-cert.yml
   - ca-issuer.yml
   - cert-manager.yml
+  - image-pull-secret.yml
   - ingress.yml
   - monitor-data-persistentvolumeclaim.yaml
   - monitor-deployment.yaml


### PR DESCRIPTION
The feature for automatic creation of an image pull secret for docker.io has been removed.

Image pull secrets should now be defined as a kubernetes manifest included in the kustomization.  The instructions in the README have been updated to show how to add an image pull secret for Dockerhub.

Fixes #11 .

Change-type: minor